### PR TITLE
Connect switchboard cleanup to the end of a request.

### DIFF
--- a/pyramid_switchboard/__init__.py
+++ b/pyramid_switchboard/__init__.py
@@ -2,14 +2,19 @@ from pyramid.config import Configurator
 from pyramid.wsgi import wsgiapp2
 
 from switchboard import configure
+from switchboard.signals import request_finished
 
 
 def request_tween_factory(handler, registry):
 
     def request_tween(request):
         from switchboard import operator
+        # Inject the request into Switchboard's context.
         operator.get_request = lambda: request
-        return handler(request)
+        response = handler(request)
+        # Notify Switchboard that we're finished with the request.
+        request_finished.send(request)
+        return response
 
     return request_tween
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
     ]
 
 setup(name='pyramid_switchboard',
-      version='0.2',
+      version='0.3',
       description=('A package which wraps the switchboard feature flipper '
                    'for Pyramid application development'),
       long_description=README,


### PR DESCRIPTION
Necessary for the caching to work properly. Without this, switches would remain cached locally, in memory, even after a change was made. Getting the switch to update would require a server restart.