### PR TITLE
Improved Makefile for 0.3 release.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+VERSION = $(shell python setup.py --version)
+
 install:
 	python setup.py develop
 	python demo/setup.py develop
@@ -5,7 +7,10 @@ install:
 demo:
 	python demo/demo.py
 
-publish:
+release:
+	git tag $(VERSION)
+	git push origin $(VERSION)
+	git push origin master
 	python setup.py sdist upload
 
-.PHONY: install demo publish
+.PHONY: install demo release


### PR DESCRIPTION
Tag the release in the git repo as part of the release process. Pull the version number automatically from the `setup.py` file.