### PR TITLE
Upgrade to latest switchboard.

### DIFF
--- a/pyramid_switchboard/__init__.py
+++ b/pyramid_switchboard/__init__.py
@@ -2,15 +2,15 @@ from pyramid.config import Configurator
 from pyramid.wsgi import wsgiapp2
 
 from switchboard import configure
+from switchboard.manager import context
 from switchboard.signals import request_finished
 
 
 def request_tween_factory(handler, registry):
 
     def request_tween(request):
-        from switchboard import operator
         # Inject the request into Switchboard's context.
-        operator.get_request = lambda: request
+        context['request'] = request
         response = handler(request)
         # Notify Switchboard that we're finished with the request.
         request_finished.send(request)

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,11 @@ except IOError:
 install_requires = [
     'pyramid',
     'pyramid_mako',
-    'switchboard'
+    'switchboard>=1.3.0'
     ]
 
 setup(name='pyramid_switchboard',
-      version='0.3',
+      version='0.4',
       description=('A package which wraps the switchboard feature flipper '
                    'for Pyramid application development'),
       long_description=README,


### PR DESCRIPTION
Switchboard 1.3 has some important fixes for race conditions on multithreaded servers, but it's also backwards-incompatible in how user and request objects are added to the context. Switch to the new approach.